### PR TITLE
feat(pipeline): implementar separação de instrumentos com Demucs local

### DIFF
--- a/app/pipeline/separator.py
+++ b/app/pipeline/separator.py
@@ -1,0 +1,367 @@
+"""
+separator.py
+Separação de instrumentos usando Demucs local com fallback para Replicate API.
+
+Modelos suportados:
+    htdemucs    → 4 faixas: vocals, drums, bass, other (padrão, mais rápido)
+    htdemucs_6s → 6 faixas: vocals, drums, bass, guitar, piano, other (mais preciso)
+
+A faixa harmônica (usada para detecção de acordes) é selecionada automaticamente
+com base nas faixas disponíveis no modelo escolhido.
+"""
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+import demucs.separate
+import torch
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constantes ────────────────────────────────────────────────────────────────
+
+# Modelos com 4 faixas: vocals, drums, bass, other
+MODELS_4_STEMS = {"htdemucs", "mdx", "mdx_extra", "mdx_q"}
+
+# Modelos com 6 faixas: vocals, drums, bass, guitar, piano, other
+MODELS_6_STEMS = {"htdemucs_6s"}
+
+# Prioridade de seleção da faixa harmônica para detecção de acordes
+# Guitarra > Piano > Other (qualquer outro instrumento melódico)
+HARMONIC_PRIORITY = ["guitar", "piano", "other"]
+
+
+# ── Enums e Dataclasses ───────────────────────────────────────────────────────
+
+class SeparationMode(Enum):
+    LOCAL    = "local"
+    REPLICATE = "replicate"
+
+
+@dataclass
+class SeparationResult:
+    """
+    Resultado da separação de instrumentos.
+
+    A faixa `harmonic` representa o instrumento melódico principal
+    disponível — pode ser guitarra, piano ou qualquer outro instrumento
+    dependendo do modelo usado e do conteúdo da música.
+
+    Atributos:
+        vocals:       Faixa vocal isolada.
+        harmonic:     Melhor faixa harmônica disponível para detecção de acordes.
+        bass:         Faixa de baixo isolada.
+        drums:        Faixa de bateria isolada.
+        guitar:       Faixa de guitarra isolada (apenas htdemucs_6s).
+        piano:        Faixa de piano isolada (apenas htdemucs_6s).
+        other:        Faixa com demais instrumentos.
+        model:        Nome do modelo Demucs utilizado.
+        harmonic_source: Nome da faixa que originou `harmonic` (guitar/piano/other).
+        mode:         Modo de execução (local ou Replicate).
+        success:      Indica se a separação foi bem-sucedida.
+        error:        Mensagem de erro, se houver.
+    """
+    vocals:          Path
+    harmonic:        Path
+    bass:            Path
+    drums:           Path
+    other:           Path
+    mode:            SeparationMode
+    success:         bool
+    model:           str            = "htdemucs"
+    harmonic_source: str            = "other"
+    guitar:          Path | None    = None
+    piano:           Path | None    = None
+    error:           str | None     = None
+
+
+# ── Função Principal ──────────────────────────────────────────────────────────
+
+def separate(audio_path: Path) -> SeparationResult:
+    """
+    Ponto de entrada principal.
+    Tenta separar localmente com Demucs, com fallback para Replicate API.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio original.
+
+    Returns:
+        SeparationResult com os caminhos das faixas separadas.
+    """
+    logger.info("Iniciando separação de instrumentos: %s", audio_path)
+
+    # Tentativa 1: Demucs local
+    try:
+        logger.info("Tentando separação com Demucs local...")
+        result = _separate_local(audio_path)
+        logger.info("✅ Separação local concluída com sucesso.")
+        logger.info(
+            "Faixa harmônica selecionada: '%s' (modelo: %s)",
+            result.harmonic_source,
+            result.model,
+        )
+        return result
+
+    except Exception as e:
+        logger.warning("⚠️ Demucs local falhou: %s", str(e))
+        logger.info("Tentando fallback para Replicate API...")
+
+    # Tentativa 2: Replicate API
+    try:
+        result = _separate_replicate(audio_path)
+        logger.info("✅ Separação via Replicate concluída com sucesso.")
+        logger.info(
+            "Faixa harmônica selecionada: '%s' (modelo: %s)",
+            result.harmonic_source,
+            result.model,
+        )
+        return result
+
+    except Exception as e:
+        logger.error("❌ Replicate API também falhou: %s", str(e))
+        return SeparationResult(
+            vocals=Path(),
+            harmonic=Path(),
+            bass=Path(),
+            drums=Path(),
+            other=Path(),
+            mode=SeparationMode.LOCAL,
+            success=False,
+            error=str(e),
+        )
+
+
+# ── Separação Local (Demucs) ──────────────────────────────────────────────────
+
+def _separate_local(audio_path: Path) -> SeparationResult:
+    """
+    Executa a separação usando Demucs localmente.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio.
+
+    Returns:
+        SeparationResult com os caminhos das faixas separadas.
+
+    Raises:
+        RuntimeError: Se a separação falhar ou arquivos não forem gerados.
+    """
+    model      = os.getenv("DEMUCS_MODEL", "htdemucs")
+    output_dir = Path(tempfile.mkdtemp(prefix="melodytab_"))
+    device     = "cuda" if torch.cuda.is_available() else "cpu"
+
+    logger.info("Modelo: %s | Dispositivo: %s | Saída: %s", model, device, output_dir)
+    logger.info("Isso pode levar alguns minutos em CPU...")
+
+    demucs.separate.main([
+        "--name",   model,
+        "--out",    str(output_dir),
+        "--device", device,
+        str(audio_path),
+    ])
+
+    stem_dir = output_dir / model / audio_path.stem
+
+    # Faixas presentes em todos os modelos
+    vocals = stem_dir / "vocals.wav"
+    bass   = stem_dir / "bass.wav"
+    drums  = stem_dir / "drums.wav"
+    other  = stem_dir / "other.wav"
+
+    # Faixas exclusivas do htdemucs_6s
+    guitar = stem_dir / "guitar.wav" if model in MODELS_6_STEMS else None
+    piano  = stem_dir / "piano.wav"  if model in MODELS_6_STEMS else None
+
+    # Valida faixas obrigatórias
+    for nome, caminho in [("vocals", vocals), ("bass", bass),
+                           ("drums", drums), ("other", other)]:
+        if not caminho.exists():
+            raise RuntimeError(
+                f"Arquivo não encontrado para '{nome}': {caminho}"
+            )
+
+    # Seleciona a melhor faixa harmônica disponível
+    harmonic, harmonic_source = _select_harmonic(
+        guitar=guitar,
+        piano=piano,
+        other=other,
+    )
+
+    return SeparationResult(
+        vocals=vocals,
+        harmonic=harmonic,
+        bass=bass,
+        drums=drums,
+        other=other,
+        guitar=guitar,
+        piano=piano,
+        mode=SeparationMode.LOCAL,
+        success=True,
+        model=model,
+        harmonic_source=harmonic_source,
+    )
+
+
+# ── Fallback: Replicate API ───────────────────────────────────────────────────
+
+def _separate_replicate(audio_path: Path) -> SeparationResult:
+    """
+    Executa a separação usando a API do Replicate como fallback.
+    Utiliza sempre o modelo htdemucs (4 faixas) no fallback.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio.
+
+    Returns:
+        SeparationResult com os caminhos das faixas separadas.
+
+    Raises:
+        RuntimeError: Se o token não estiver configurado ou a API falhar.
+    """
+    import replicate
+    import requests
+
+    token = os.getenv("REPLICATE_API_TOKEN")
+    if not token:
+        raise RuntimeError("REPLICATE_API_TOKEN não configurado no .env")
+
+    logger.info("Enviando áudio para Replicate API...")
+
+    with open(audio_path, "rb") as f:
+        output = replicate.run(
+            "cjwbw/demucs:25a173108cff36ef9f80f854c162d01df9e6528be175794b81158fa03836d953",
+            input={"audio": f, "model": "htdemucs"},
+        )
+
+    # Replicate retorna URLs para cada faixa
+    output_dir = Path(tempfile.mkdtemp(prefix="melodytab_replicate_"))
+
+    urls = {
+        "vocals": output.get("vocals"),
+        "other":  output.get("other"),
+        "bass":   output.get("bass"),
+        "drums":  output.get("drums"),
+    }
+
+    # Valida e baixa todas as faixas
+    caminhos = {}
+    for nome, url in urls.items():
+        if not url:
+            raise RuntimeError(
+                f"Replicate não retornou URL para a faixa '{nome}'"
+            )
+        destino = output_dir / f"{nome}.wav"
+        logger.info("Baixando faixa '%s'...", nome)
+        _download_file(url, destino)
+        caminhos[nome] = destino
+
+    # No fallback (htdemucs 4 faixas), harmonic vem direto de other
+    harmonic, harmonic_source = _select_harmonic(
+        guitar=None,
+        piano=None,
+        other=caminhos["other"],
+    )
+
+    return SeparationResult(
+        vocals=caminhos["vocals"],
+        harmonic=harmonic,
+        bass=caminhos["bass"],
+        drums=caminhos["drums"],
+        other=caminhos["other"],
+        guitar=None,
+        piano=None,
+        mode=SeparationMode.REPLICATE,
+        success=True,
+        model="htdemucs",
+        harmonic_source=harmonic_source,
+    )
+
+
+# ── Seleção da Faixa Harmônica ────────────────────────────────────────────────
+
+def _select_harmonic(
+    guitar: Path | None,
+    piano:  Path | None,
+    other:  Path,
+) -> tuple[Path, str]:
+    """
+    Seleciona a melhor faixa harmônica para detecção de acordes.
+
+    Prioridade: guitarra → piano → other.
+    Uma faixa é considerada válida se existir e tiver conteúdo de áudio.
+
+    Args:
+        guitar: Caminho para a faixa de guitarra (None se modelo 4 faixas).
+        piano:  Caminho para a faixa de piano (None se modelo 4 faixas).
+        other:  Caminho para a faixa other (sempre presente).
+
+    Returns:
+        Tupla (caminho_da_faixa, nome_da_fonte).
+    """
+    candidatas = [
+        ("guitar", guitar),
+        ("piano",  piano),
+        ("other",  other),
+    ]
+
+    for nome, caminho in candidatas:
+        if caminho and caminho.exists() and _has_audio_content(caminho):
+            logger.info("Faixa harmônica selecionada: '%s'", nome)
+            return caminho, nome
+
+    # Se tudo falhar, usa other sem verificação
+    logger.warning(
+        "Nenhuma faixa harmônica com conteúdo encontrada. Usando 'other' como fallback."
+    )
+    return other, "other"
+
+
+def _has_audio_content(path: Path, min_size_bytes: int = 1024) -> bool:
+    """
+    Verifica se um arquivo de áudio tem conteúdo relevante.
+    Usa o tamanho do arquivo como heurística rápida.
+
+    Args:
+        path:           Caminho para o arquivo de áudio.
+        min_size_bytes: Tamanho mínimo em bytes para considerar válido.
+
+    Returns:
+        True se o arquivo tem conteúdo, False caso contrário.
+    """
+    try:
+        return path.stat().st_size > min_size_bytes
+    except OSError:
+        return False
+
+
+# ── Utilitários ───────────────────────────────────────────────────────────────
+
+def _download_file(url: str, destino: Path) -> None:
+    """
+    Faz o download de um arquivo de uma URL para um caminho local.
+
+    Args:
+        url:     URL do arquivo a baixar.
+        destino: Caminho local onde o arquivo será salvo.
+
+    Raises:
+        requests.HTTPError: Se o download falhar.
+    """
+    import requests
+
+    response = requests.get(url, stream=True, timeout=120)
+    response.raise_for_status()
+
+    with open(destino, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    logger.info("Download concluído: %s (%d bytes)", destino, destino.stat().st_size)

--- a/tests/unit/test_separator.py
+++ b/tests/unit/test_separator.py
@@ -1,0 +1,258 @@
+"""
+test_separator.py
+Testes unitários para o módulo separator.py
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.pipeline.separator import (
+    SeparationMode,
+    SeparationResult,
+    _has_audio_content,
+    _select_harmonic,
+    separate,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def audio_path(tmp_path):
+    """Cria um arquivo de áudio falso para os testes."""
+    audio = tmp_path / "musica.mp3"
+    audio.write_bytes(b"fake audio content")
+    return audio
+
+
+@pytest.fixture
+def stem_dir(tmp_path):
+    """Cria um diretório com faixas separadas falsas."""
+    stems = tmp_path / "htdemucs" / "musica"
+    stems.mkdir(parents=True)
+
+    for nome in ["vocals", "bass", "drums", "other"]:
+        faixa = stems / f"{nome}.wav"
+        faixa.write_bytes(b"x" * 2048)  # conteúdo suficiente para passar _has_audio_content
+
+    return stems
+
+
+@pytest.fixture
+def stem_dir_6s(tmp_path):
+    """Cria um diretório com faixas do modelo htdemucs_6s."""
+    stems = tmp_path / "htdemucs_6s" / "musica"
+    stems.mkdir(parents=True)
+
+    for nome in ["vocals", "bass", "drums", "other", "guitar", "piano"]:
+        faixa = stems / f"{nome}.wav"
+        faixa.write_bytes(b"x" * 2048)
+
+    return stems
+
+
+# ── Testes: _has_audio_content ────────────────────────────────────────────────
+
+class TestHasAudioContent:
+
+    def test_arquivo_com_conteudo_suficiente(self, tmp_path):
+        """Deve retornar True para arquivo maior que o mínimo."""
+        arquivo = tmp_path / "audio.wav"
+        arquivo.write_bytes(b"x" * 2048)
+        assert _has_audio_content(arquivo) is True
+
+    def test_arquivo_muito_pequeno(self, tmp_path):
+        """Deve retornar False para arquivo menor que 1024 bytes."""
+        arquivo = tmp_path / "audio.wav"
+        arquivo.write_bytes(b"x" * 10)
+        assert _has_audio_content(arquivo) is False
+
+    def test_arquivo_inexistente(self, tmp_path):
+        """Deve retornar False para arquivo que não existe."""
+        arquivo = tmp_path / "nao_existe.wav"
+        assert _has_audio_content(arquivo) is False
+
+
+# ── Testes: _select_harmonic ──────────────────────────────────────────────────
+
+class TestSelectHarmonic:
+
+    def test_prioriza_guitarra_quando_disponivel(self, tmp_path):
+        """Deve selecionar guitarra quando disponível e com conteúdo."""
+        guitar = tmp_path / "guitar.wav"
+        piano  = tmp_path / "piano.wav"
+        other  = tmp_path / "other.wav"
+
+        guitar.write_bytes(b"x" * 2048)
+        piano.write_bytes(b"x" * 2048)
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=guitar, piano=piano, other=other)
+
+        assert caminho == guitar
+        assert fonte == "guitar"
+
+    def test_usa_piano_quando_guitarra_ausente(self, tmp_path):
+        """Deve selecionar piano quando guitarra não está disponível."""
+        piano = tmp_path / "piano.wav"
+        other = tmp_path / "other.wav"
+
+        piano.write_bytes(b"x" * 2048)
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=None, piano=piano, other=other)
+
+        assert caminho == piano
+        assert fonte == "piano"
+
+    def test_usa_other_quando_guitarra_e_piano_ausentes(self, tmp_path):
+        """Deve selecionar other quando guitarra e piano não estão disponíveis."""
+        other = tmp_path / "other.wav"
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=None, piano=None, other=other)
+
+        assert caminho == other
+        assert fonte == "other"
+
+    def test_ignora_guitarra_sem_conteudo(self, tmp_path):
+        """Deve ignorar guitarra com arquivo muito pequeno e usar piano."""
+        guitar = tmp_path / "guitar.wav"
+        piano  = tmp_path / "piano.wav"
+        other  = tmp_path / "other.wav"
+
+        guitar.write_bytes(b"x" * 10)   # muito pequeno — inválido
+        piano.write_bytes(b"x" * 2048)
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=guitar, piano=piano, other=other)
+
+        assert caminho == piano
+        assert fonte == "piano"
+
+
+# ── Testes: separate (fluxo principal) ───────────────────────────────────────
+
+class TestSeparate:
+
+    @patch("app.pipeline.separator._separate_local")
+    def test_usa_local_quando_disponivel(self, mock_local, audio_path, tmp_path):
+        """Deve usar Demucs local e retornar modo LOCAL."""
+        mock_result = SeparationResult(
+            vocals=tmp_path / "vocals.wav",
+            harmonic=tmp_path / "other.wav",
+            bass=tmp_path / "bass.wav",
+            drums=tmp_path / "drums.wav",
+            other=tmp_path / "other.wav",
+            mode=SeparationMode.LOCAL,
+            success=True,
+            harmonic_source="other",
+        )
+        mock_local.return_value = mock_result
+
+        result = separate(audio_path)
+
+        assert result.success is True
+        assert result.mode == SeparationMode.LOCAL
+        mock_local.assert_called_once_with(audio_path)
+
+    @patch("app.pipeline.separator._separate_replicate")
+    @patch("app.pipeline.separator._separate_local")
+    def test_usa_fallback_quando_local_falha(
+        self, mock_local, mock_replicate, audio_path, tmp_path
+    ):
+        """Deve usar Replicate quando Demucs local lançar exceção."""
+        mock_local.side_effect = RuntimeError("Demucs falhou")
+
+        mock_result = SeparationResult(
+            vocals=tmp_path / "vocals.wav",
+            harmonic=tmp_path / "other.wav",
+            bass=tmp_path / "bass.wav",
+            drums=tmp_path / "drums.wav",
+            other=tmp_path / "other.wav",
+            mode=SeparationMode.REPLICATE,
+            success=True,
+            harmonic_source="other",
+        )
+        mock_replicate.return_value = mock_result
+
+        result = separate(audio_path)
+
+        assert result.success is True
+        assert result.mode == SeparationMode.REPLICATE
+        mock_local.assert_called_once()
+        mock_replicate.assert_called_once()
+
+    @patch("app.pipeline.separator._separate_replicate")
+    @patch("app.pipeline.separator._separate_local")
+    def test_retorna_erro_quando_tudo_falha(
+        self, mock_local, mock_replicate, audio_path
+    ):
+        """Deve retornar SeparationResult com success=False quando ambos falham."""
+        mock_local.side_effect     = RuntimeError("Demucs falhou")
+        mock_replicate.side_effect = RuntimeError("Replicate falhou")
+
+        result = separate(audio_path)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Replicate falhou" in result.error
+
+    @patch("app.pipeline.separator._separate_local")
+    def test_nao_chama_replicate_quando_local_funciona(
+        self, mock_local, audio_path, tmp_path
+    ):
+        """Não deve chamar Replicate quando Demucs local funciona."""
+        mock_local.return_value = SeparationResult(
+            vocals=tmp_path / "vocals.wav",
+            harmonic=tmp_path / "other.wav",
+            bass=tmp_path / "bass.wav",
+            drums=tmp_path / "drums.wav",
+            other=tmp_path / "other.wav",
+            mode=SeparationMode.LOCAL,
+            success=True,
+            harmonic_source="other",
+        )
+
+        with patch("app.pipeline.separator._separate_replicate") as mock_replicate:
+            result = separate(audio_path)
+            mock_replicate.assert_not_called()
+
+        assert result.success is True
+
+
+# ── Testes: modelo htdemucs_6s ────────────────────────────────────────────────
+
+class TestModelo6Stems:
+
+    def test_seleciona_guitarra_no_modelo_6s(self, tmp_path):
+        """Com htdemucs_6s, deve priorizar guitarra sobre other."""
+        guitar = tmp_path / "guitar.wav"
+        piano  = tmp_path / "piano.wav"
+        other  = tmp_path / "other.wav"
+
+        guitar.write_bytes(b"x" * 2048)
+        piano.write_bytes(b"x" * 2048)
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=guitar, piano=piano, other=other)
+
+        assert fonte == "guitar"
+        assert caminho == guitar
+
+    def test_seleciona_piano_quando_guitarra_vazia_no_modelo_6s(self, tmp_path):
+        """Com htdemucs_6s, deve usar piano quando guitarra está vazia."""
+        guitar = tmp_path / "guitar.wav"
+        piano  = tmp_path / "piano.wav"
+        other  = tmp_path / "other.wav"
+
+        guitar.write_bytes(b"x" * 10)   # silêncio — inválido
+        piano.write_bytes(b"x" * 2048)
+        other.write_bytes(b"x" * 2048)
+
+        caminho, fonte = _select_harmonic(guitar=guitar, piano=piano, other=other)
+
+        assert fonte == "piano"
+        assert caminho == piano


### PR DESCRIPTION
## O que foi feito?
Implementação do módulo separator.py responsável pela separação de instrumentos do áudio.

## Tipo de Mudança
- [x] Nova funcionalidade (feat)

## Issue Relacionada
Closes #1

## Checklist
- [x] O código segue o padrão do projeto (ruff + black)
- [x] Os testes existentes continuam passando
- [x] Novos testes foram adicionados
- [x] A documentação foi atualizada

## Como Testar
1. Instalar dependências: make install-dev
2. Rodar os testes: make test-unit