### PR TITLE
feat(pipeline): implementar formatação da cifra com Groq LLaMA

### DIFF
--- a/app/pipeline/formatter.py
+++ b/app/pipeline/formatter.py
@@ -1,0 +1,252 @@
+"""
+formatter.py
+Formatação do resultado do alinhamento no padrão de cifra brasileiro.
+
+Recebe o AlignmentResult do aligner.py e gera a cifra final em dois passos:
+1. Monta a cifra bruta localmente a partir das estruturas de dados
+2. Usa o Groq LLaMA para polir e padronizar a formatação final
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+from groq import Groq
+
+from app.pipeline.aligner import AlignedLine, AlignedWord, AlignmentResult
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Modelo LLaMA usado para polimento da cifra
+LLAMA_MODEL = "llama-3.3-70b-versatile"
+
+
+# ── Dataclasses ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FormattedChord:
+    """
+    Resultado da formatação da cifra.
+
+    Atributos:
+        raw:      Cifra bruta gerada localmente.
+        polished: Cifra polida pelo LLaMA.
+        success:  Indica se a formatação foi bem-sucedida.
+        error:    Mensagem de erro, se houver.
+    """
+
+    raw: str
+    polished: str
+    success: bool
+    error: str | None = None
+
+
+# ── Função Principal ──────────────────────────────────────────────────────────
+
+
+def format_chord(alignment: AlignmentResult) -> FormattedChord:
+    """
+    Formata o resultado do alinhamento em uma cifra melódica.
+
+    Args:
+        alignment: Resultado do alinhamento de letra, acordes e melodia.
+
+    Returns:
+        FormattedChord com a cifra bruta e a cifra polida pelo LLaMA.
+    """
+    logger.info("Iniciando formatação da cifra...")
+
+    try:
+        # Passo 1: gera a cifra bruta localmente
+        logger.info("Gerando cifra bruta...")
+        raw = _build_raw_chord(alignment.lines)
+        logger.info("Cifra bruta gerada:\n%s", raw)
+
+        # Passo 2: polish com LLaMA
+        logger.info("Enviando para Groq LLaMA para polimento...")
+        polished = _polish_with_llama(raw)
+        logger.info("✅ Cifra polida com sucesso.")
+
+        return FormattedChord(raw=raw, polished=polished, success=True)
+
+    except Exception as e:
+        logger.error("❌ Formatação falhou: %s", str(e))
+        return FormattedChord(raw="", polished="", success=False, error=str(e))
+
+
+# ── Geração da Cifra Bruta ────────────────────────────────────────────────────
+
+
+def _build_raw_chord(lines: list[AlignedLine]) -> str:
+    """
+    Gera a cifra bruta a partir das linhas alinhadas.
+
+    Formato de saída para cada linha:
+        Linha de acordes: [C]        [Am]
+        Linha de melodia: mi sol lá   mi ré dó
+        Linha de letra:   quando o sol se pôr
+
+    Args:
+        lines: Lista de linhas alinhadas do AlignmentResult.
+
+    Returns:
+        String com a cifra bruta formatada.
+    """
+    resultado = []
+
+    for linha in lines:
+        chord_line = _build_chord_line(linha.words)
+        melody_line = _build_melody_line(linha.words)
+        lyric_line = _build_lyric_line(linha.words)
+
+        # Adiciona as 3 linhas se tiverem conteúdo
+        if chord_line.strip():
+            resultado.append(chord_line)
+        if melody_line.strip():
+            resultado.append(melody_line)
+        resultado.append(lyric_line)
+        resultado.append("")  # linha em branco entre estrofes
+
+    return "\n".join(resultado).strip()
+
+
+def _build_chord_line(words: list[AlignedWord]) -> str:
+    """
+    Monta a linha de acordes alinhada com as palavras.
+
+    Acordes são inseridos entre colchetes na posição da palavra
+    onde ocorre a mudança de acorde.
+
+    Args:
+        words: Lista de palavras de uma linha.
+
+    Returns:
+        String com os acordes posicionados sobre as palavras.
+    """
+    chord_line = ""
+    lyric_line = ""
+
+    for word in words:
+        palavra = word.word + " "
+
+        if word.chord_change and word.chord:
+            acorde = f"[{word.chord}]"
+
+            # Alinha o acorde com a posição da palavra na letra
+            pos_acorde = len(lyric_line)
+            pos_atual = len(chord_line)
+
+            if pos_atual < pos_acorde:
+                chord_line += " " * (pos_acorde - pos_atual)
+
+            chord_line += acorde
+
+        lyric_line += palavra
+
+    return chord_line
+
+
+def _build_melody_line(words: list[AlignedWord]) -> str:
+    """
+    Monta a linha de melodia com as notas posicionadas sob as palavras.
+
+    Args:
+        words: Lista de palavras de uma linha.
+
+    Returns:
+        String com as notas posicionadas sob as palavras.
+    """
+    melody_line = ""
+    lyric_line = ""
+
+    for word in words:
+        palavra = word.word + " "
+
+        if word.note:
+            nota = word.note + " "
+
+            # Alinha a nota com a posição da palavra
+            pos_palavra = len(lyric_line)
+            pos_atual = len(melody_line)
+
+            if pos_atual < pos_palavra:
+                melody_line += " " * (pos_palavra - pos_atual)
+
+            melody_line += nota
+
+        lyric_line += palavra
+
+    return melody_line
+
+
+def _build_lyric_line(words: list[AlignedWord]) -> str:
+    """
+    Monta a linha de letra juntando as palavras com espaços.
+
+    Args:
+        words: Lista de palavras de uma linha.
+
+    Returns:
+        String com a letra da linha.
+    """
+    return " ".join(w.word for w in words)
+
+
+# ── Polimento com LLaMA ───────────────────────────────────────────────────────
+
+
+def _polish_with_llama(raw_chord: str) -> str:
+    """
+    Usa o Groq LLaMA para polir e padronizar a cifra bruta.
+
+    O LLaMA corrige espaçamentos, padroniza notação de acordes,
+    ajusta quebras de linha e garante que a cifra siga o padrão
+    brasileiro de forma legível.
+
+    Args:
+        raw_chord: Cifra bruta gerada localmente.
+
+    Returns:
+        Cifra polida e padronizada pelo LLaMA.
+
+    Raises:
+        RuntimeError: Se a chave da API não estiver configurada.
+    """
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "GROQ_API_KEY não configurada. " "Adicione sua chave ao arquivo .env."
+        )
+
+    client = Groq(api_key=api_key)
+
+    prompt = f"""Você é um especialista em cifras musicais brasileiras.
+Receba a cifra bruta abaixo e faça apenas os seguintes ajustes:
+
+1. Corrija espaçamentos entre acordes e palavras
+2. Padronize a notação dos acordes (ex: Bbm em vez de A#m)
+3. Ajuste quebras de linha para melhor legibilidade
+4. Mantenha as notas da melodia alinhadas com as palavras
+5. NÃO altere os acordes detectados, apenas a formatação
+6. NÃO adicione acordes que não estejam na cifra bruta
+7. Retorne APENAS a cifra formatada, sem explicações
+
+CIFRA BRUTA:
+{raw_chord}
+"""
+
+    response = client.chat.completions.create(
+        model=LLAMA_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.1,  # baixa temperatura para saída consistente
+        max_tokens=2048,
+    )
+
+    polished = response.choices[0].message.content.strip()
+    logger.info("LLaMA retornou %d caracteres.", len(polished))
+
+    return polished

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,251 @@
+"""
+test_formatter.py
+Testes unitários para o módulo formatter.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.pipeline.aligner import AlignedLine, AlignedWord, AlignmentResult
+from app.pipeline.formatter import (
+    _build_chord_line,
+    _build_lyric_line,
+    _build_melody_line,
+    _build_raw_chord,
+    _polish_with_llama,
+    format_chord,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def words_linha_1():
+    """Primeira linha: 'quando o sol' com acordes e notas."""
+    return [
+        AlignedWord(
+            "quando", 0.0, 0.5, chord="C", note="E", octave=4, chord_change=True
+        ),
+        AlignedWord("o", 0.5, 0.7, chord="C", note="G", octave=4, chord_change=False),
+        AlignedWord("sol", 0.7, 1.0, chord="Am", note="A", octave=4, chord_change=True),
+    ]
+
+
+@pytest.fixture
+def words_sem_acorde():
+    """Palavras sem acorde nem nota."""
+    return [
+        AlignedWord("palavra", 0.0, 0.5),
+        AlignedWord("simples", 0.5, 1.0),
+    ]
+
+
+@pytest.fixture
+def linha_1(words_linha_1):
+    """AlignedLine com palavras da primeira linha."""
+    return AlignedLine(
+        words=words_linha_1,
+        start_time=0.0,
+        end_time=1.0,
+    )
+
+
+@pytest.fixture
+def alignment_result(linha_1):
+    """AlignmentResult com uma linha."""
+    return AlignmentResult(lines=[linha_1], success=True)
+
+
+# ── Testes: _build_lyric_line ─────────────────────────────────────────────────
+
+
+class TestBuildLyricLine:
+
+    def test_junta_palavras_com_espacos(self, words_linha_1):
+        """Deve juntar todas as palavras com espaços."""
+        resultado = _build_lyric_line(words_linha_1)
+        assert resultado == "quando o sol"
+
+    def test_lista_vazia_retorna_string_vazia(self):
+        """Lista vazia deve retornar string vazia."""
+        assert _build_lyric_line([]) == ""
+
+    def test_uma_palavra(self):
+        """Lista com uma palavra deve retornar só ela."""
+        words = [AlignedWord("olá", 0.0, 0.5)]
+        assert _build_lyric_line(words) == "olá"
+
+
+# ── Testes: _build_chord_line ─────────────────────────────────────────────────
+
+
+class TestBuildChordLine:
+
+    def test_insere_acordes_em_colchetes(self, words_linha_1):
+        """Acordes devem aparecer entre colchetes."""
+        resultado = _build_chord_line(words_linha_1)
+        assert "[C]" in resultado
+        assert "[Am]" in resultado
+
+    def test_sem_acorde_retorna_string_vazia(self, words_sem_acorde):
+        """Palavras sem acorde devem retornar linha de acordes vazia."""
+        resultado = _build_chord_line(words_sem_acorde)
+        assert resultado.strip() == ""
+
+    def test_acorde_posicionado_antes_da_palavra(self, words_linha_1):
+        """Acorde [C] deve aparecer antes de [Am] na linha."""
+        resultado = _build_chord_line(words_linha_1)
+        pos_c = resultado.find("[C]")
+        pos_am = resultado.find("[Am]")
+        assert pos_c < pos_am
+
+    def test_apenas_chord_change_gera_acorde(self):
+        """Apenas palavras com chord_change=True devem gerar acorde na linha."""
+        words = [
+            AlignedWord("a", 0.0, 0.5, chord="G", chord_change=True),
+            AlignedWord("b", 0.5, 1.0, chord="G", chord_change=False),
+            AlignedWord("c", 1.0, 1.5, chord="G", chord_change=False),
+        ]
+        resultado = _build_chord_line(words)
+        assert resultado.count("[G]") == 1
+
+
+# ── Testes: _build_melody_line ────────────────────────────────────────────────
+
+
+class TestBuildMelodyLine:
+
+    def test_insere_notas_nas_posicoes_corretas(self, words_linha_1):
+        """Notas devem aparecer na linha de melodia."""
+        resultado = _build_melody_line(words_linha_1)
+        assert "E" in resultado
+        assert "G" in resultado
+        assert "A" in resultado
+
+    def test_sem_nota_retorna_string_vazia(self, words_sem_acorde):
+        """Palavras sem nota devem retornar linha de melodia vazia."""
+        resultado = _build_melody_line(words_sem_acorde)
+        assert resultado.strip() == ""
+
+    def test_notas_em_ordem(self, words_linha_1):
+        """Notas devem aparecer na ordem das palavras."""
+        resultado = _build_melody_line(words_linha_1)
+        pos_e = resultado.find("E")
+        pos_g = resultado.find("G")
+        pos_a = resultado.find("A")
+        assert pos_e < pos_g < pos_a
+
+
+# ── Testes: _build_raw_chord ──────────────────────────────────────────────────
+
+
+class TestBuildRawChord:
+
+    def test_gera_cifra_com_tres_linhas(self, linha_1):
+        """Deve gerar linha de acordes, melodia e letra."""
+        resultado = _build_raw_chord([linha_1])
+        assert "[C]" in resultado
+        assert "E" in resultado
+        assert "quando" in resultado
+
+    def test_linhas_separadas_por_quebra(self, linha_1):
+        """Acordes, melodia e letra devem estar em linhas separadas."""
+        resultado = _build_raw_chord([linha_1])
+        linhas = resultado.split("\n")
+        assert len(linhas) >= 3
+
+    def test_lista_vazia_retorna_string_vazia(self):
+        """Lista vazia deve retornar string vazia."""
+        assert _build_raw_chord([]) == ""
+
+
+# ── Testes: _polish_with_llama ────────────────────────────────────────────────
+
+
+class TestPolishWithLlama:
+
+    @patch("app.pipeline.formatter.Groq")
+    def test_retorna_cifra_polida(self, mock_groq_class):
+        """Deve retornar o texto retornado pelo LLaMA."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="  cifra polida  "))]
+        )
+        mock_groq_class.return_value = mock_client
+
+        with patch.dict("os.environ", {"GROQ_API_KEY": "gsk_test"}):
+            resultado = _polish_with_llama("cifra bruta")
+
+        assert resultado == "cifra polida"
+
+    @patch("app.pipeline.formatter.Groq")
+    def test_chama_llama_com_temperatura_baixa(self, mock_groq_class):
+        """Deve usar temperatura baixa para saída consistente."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="cifra"))]
+        )
+        mock_groq_class.return_value = mock_client
+
+        with patch.dict("os.environ", {"GROQ_API_KEY": "gsk_test"}):
+            _polish_with_llama("cifra bruta")
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["temperature"] == pytest.approx(0.1)
+        assert call_kwargs["model"] == "llama-3.3-70b-versatile"
+
+    def test_erro_sem_api_key(self):
+        """Deve lançar RuntimeError sem GROQ_API_KEY."""
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError, match="GROQ_API_KEY"):
+                _polish_with_llama("cifra bruta")
+
+
+# ── Testes: format_chord (fluxo principal) ────────────────────────────────────
+
+
+class TestFormatChord:
+
+    @patch("app.pipeline.formatter._polish_with_llama")
+    def test_fluxo_completo_com_sucesso(self, mock_polish, alignment_result):
+        """Deve retornar FormattedChord com sucesso."""
+        mock_polish.return_value = "cifra polida pelo llama"
+
+        resultado = format_chord(alignment_result)
+
+        assert resultado.success is True
+        assert resultado.polished == "cifra polida pelo llama"
+        assert resultado.raw != ""
+        mock_polish.assert_called_once()
+
+    @patch("app.pipeline.formatter._polish_with_llama")
+    def test_raw_contem_acordes_e_letra(self, mock_polish, alignment_result):
+        """Cifra bruta deve conter acordes e letra."""
+        mock_polish.return_value = "polida"
+
+        resultado = format_chord(alignment_result)
+
+        assert "[C]" in resultado.raw
+        assert "quando" in resultado.raw
+
+    @patch("app.pipeline.formatter._polish_with_llama")
+    def test_retorna_erro_quando_polish_falha(self, mock_polish, alignment_result):
+        """Deve retornar FormattedChord com success=False quando LLaMA falha."""
+        mock_polish.side_effect = RuntimeError("LLaMA indisponível")
+
+        resultado = format_chord(alignment_result)
+
+        assert resultado.success is False
+        assert "LLaMA indisponível" in resultado.error
+
+    @patch("app.pipeline.formatter._polish_with_llama")
+    def test_polish_recebe_cifra_bruta(self, mock_polish, alignment_result):
+        """O LLaMA deve receber a cifra bruta como entrada."""
+        mock_polish.return_value = "polida"
+
+        resultado = format_chord(alignment_result)
+
+        args = mock_polish.call_args.args
+        assert args[0] == resultado.raw


### PR DESCRIPTION
## O que foi feito?
Implementação do módulo formatter.py responsável por formatar o resultado do alinhamento no padrão de cifra brasileiro.

## Tipo de Mudança
- [x] Nova funcionalidade (feat)

## Issue Relacionada
Closes #5

## Checklist
- [x] O código segue o padrão do projeto (ruff + black)
- [x] Os testes existentes continuam passando
- [x] Novos testes foram adicionados
- [x] A documentação foi atualizada

## Como Testar
1. Ativar o ambiente: source .venv/bin/activate
2. Rodar os testes: .venv/bin/pytest tests/unit/test_formatter.py -v