### PR TITLE
feat(separator): implementar cache de separação Demucs

### DIFF
--- a/app/pipeline/separator.py
+++ b/app/pipeline/separator.py
@@ -88,9 +88,14 @@ class SeparationResult:
 # ── Função Principal ──────────────────────────────────────────────────────────
 
 
+# Diretório de cache para faixas separadas
+CACHE_DIR = Path.home() / ".melodytab_cache" / "separated"
+
+
 def separate(audio_path: Path) -> SeparationResult:
     """
     Ponto de entrada principal.
+    Verifica o cache antes de separar, evitando reprocessamento.
     Tenta separar localmente com Demucs, com fallback para Replicate API.
 
     Args:
@@ -100,6 +105,12 @@ def separate(audio_path: Path) -> SeparationResult:
         SeparationResult com os caminhos das faixas separadas.
     """
     logger.info("Iniciando separação de instrumentos: %s", audio_path)
+
+    # Verifica cache
+    cache_result = _load_from_cache(audio_path)
+    if cache_result:
+        logger.info("✅ Faixas carregadas do cache.")
+        return cache_result
 
     # Tentativa 1: Demucs local
     try:
@@ -111,6 +122,7 @@ def separate(audio_path: Path) -> SeparationResult:
             result.harmonic_source,
             result.model,
         )
+        _save_to_cache(audio_path, result)
         return result
 
     except Exception as e:
@@ -126,6 +138,7 @@ def separate(audio_path: Path) -> SeparationResult:
             result.harmonic_source,
             result.model,
         )
+        _save_to_cache(audio_path, result)
         return result
 
     except Exception as e:
@@ -350,6 +363,122 @@ def _has_audio_content(path: Path, min_size_bytes: int = 1024) -> bool:
         return path.stat().st_size > min_size_bytes
     except OSError:
         return False
+
+
+# ── Cache de Separação ────────────────────────────────────────────────────────
+
+
+def _get_cache_key(audio_path: Path) -> str:
+    """
+    Gera uma chave de cache baseada no hash MD5 do arquivo de áudio.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio.
+
+    Returns:
+        String com o hash MD5 do arquivo.
+    """
+    import hashlib
+
+    md5 = hashlib.md5()
+    with open(audio_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            md5.update(chunk)
+    return md5.hexdigest()
+
+
+def _load_from_cache(audio_path: Path) -> SeparationResult | None:
+    """
+    Tenta carregar as faixas separadas do cache.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio original.
+
+    Returns:
+        SeparationResult com as faixas do cache, ou None se não encontrado.
+    """
+    try:
+        cache_key = _get_cache_key(audio_path)
+        cache_path = CACHE_DIR / cache_key
+
+        if not cache_path.exists():
+            logger.info("Cache não encontrado para: %s", audio_path.name)
+            return None
+
+        vocals = cache_path / "vocals.wav"
+        bass = cache_path / "bass.wav"
+        drums = cache_path / "drums.wav"
+        other = cache_path / "other.wav"
+        harmonic = cache_path / "harmonic.wav"
+
+        # Valida que todos os arquivos existem
+        for nome, caminho in [
+            ("vocals", vocals),
+            ("bass", bass),
+            ("drums", drums),
+            ("other", other),
+            ("harmonic", harmonic),
+        ]:
+            if not caminho.exists():
+                logger.warning("Cache incompleto — falta '%s'. Ignorando.", nome)
+                return None
+
+        model = os.getenv("DEMUCS_MODEL", "htdemucs")
+        logger.info("Cache encontrado: %s (%s)", cache_key[:8], audio_path.name)
+
+        return SeparationResult(
+            vocals=vocals,
+            harmonic=harmonic,
+            bass=bass,
+            drums=drums,
+            other=other,
+            mode=SeparationMode.LOCAL,
+            success=True,
+            model=model,
+            harmonic_source="other",
+        )
+
+    except Exception as e:
+        logger.warning("Erro ao carregar cache: %s", str(e))
+        return None
+
+
+def _save_to_cache(audio_path: Path, result: SeparationResult) -> None:
+    """
+    Salva as faixas separadas no cache para reutilização futura.
+
+    Args:
+        audio_path: Caminho para o arquivo de áudio original.
+        result:     Resultado da separação a ser cacheado.
+    """
+    try:
+        import shutil
+
+        cache_key = _get_cache_key(audio_path)
+        cache_path = CACHE_DIR / cache_key
+        cache_path.mkdir(parents=True, exist_ok=True)
+
+        # Copia as faixas para o diretório de cache
+        faixas = {
+            "vocals.wav": result.vocals,
+            "bass.wav": result.bass,
+            "drums.wav": result.drums,
+            "other.wav": result.other,
+            "harmonic.wav": result.harmonic,
+        }
+
+        for nome, origem in faixas.items():
+            if origem and origem.exists():
+                shutil.copy2(origem, cache_path / nome)
+
+        logger.info(
+            "Faixas salvas no cache: %s (%s)",
+            cache_key[:8],
+            audio_path.name,
+        )
+
+    except Exception as e:
+        logger.warning("Erro ao salvar cache: %s", str(e))
 
 
 # ── Utilitários ───────────────────────────────────────────────────────────────

--- a/tests/unit/test_separator.py
+++ b/tests/unit/test_separator.py
@@ -262,3 +262,118 @@ class TestModelo6Stems:
 
         assert fonte == "piano"
         assert caminho == piano
+
+
+# ── Testes: Cache de Separação ────────────────────────────────────────────────
+
+
+class TestCache:
+
+    @patch("app.pipeline.separator._get_cache_key")
+    def test_carrega_do_cache_quando_disponivel(self, mock_key, audio_path, tmp_path):
+        """Deve retornar resultado do cache sem chamar Demucs."""
+        cache_dir = tmp_path / "cache" / "abc123"
+        cache_dir.mkdir(parents=True)
+
+        for nome in [
+            "vocals.wav",
+            "bass.wav",
+            "drums.wav",
+            "other.wav",
+            "harmonic.wav",
+        ]:
+            (cache_dir / nome).write_bytes(b"x" * 2048)
+
+        mock_key.return_value = "abc123"
+
+        with patch("app.pipeline.separator.CACHE_DIR", tmp_path / "cache"):
+            with patch("app.pipeline.separator._separate_local") as mock_local:
+                result = separate(audio_path)
+
+                assert result.success is True
+                mock_local.assert_not_called()
+
+    @patch("app.pipeline.separator._save_to_cache")
+    @patch("app.pipeline.separator._load_from_cache")
+    @patch("app.pipeline.separator._separate_local")
+    def test_salva_no_cache_apos_separacao(
+        self, mock_local, mock_load, mock_save, audio_path, tmp_path
+    ):
+        """Deve salvar no cache após separação bem-sucedida."""
+        mock_load.return_value = None
+        mock_local.return_value = SeparationResult(
+            vocals=tmp_path / "vocals.wav",
+            harmonic=tmp_path / "other.wav",
+            bass=tmp_path / "bass.wav",
+            drums=tmp_path / "drums.wav",
+            other=tmp_path / "other.wav",
+            mode=SeparationMode.LOCAL,
+            success=True,
+            harmonic_source="other",
+        )
+
+        separate(audio_path)
+
+        mock_save.assert_called_once()
+
+    @patch("app.pipeline.separator._load_from_cache")
+    @patch("app.pipeline.separator._separate_local")
+    def test_nao_salva_cache_quando_separacao_falha(
+        self, mock_local, mock_load, audio_path
+    ):
+        """Não deve salvar no cache quando a separação falha."""
+        mock_load.return_value = None
+        mock_local.side_effect = RuntimeError("Demucs falhou")
+
+        with patch("app.pipeline.separator._separate_replicate") as mock_rep:
+            mock_rep.side_effect = RuntimeError("Replicate falhou")
+            with patch("app.pipeline.separator._save_to_cache") as mock_save:
+                result = separate(audio_path)
+
+                assert result.success is False
+                mock_save.assert_not_called()
+
+    def test_get_cache_key_retorna_md5(self, audio_path):
+        """Deve retornar hash MD5 consistente para o mesmo arquivo."""
+        from app.pipeline.separator import _get_cache_key
+
+        key1 = _get_cache_key(audio_path)
+        key2 = _get_cache_key(audio_path)
+
+        assert key1 == key2
+        assert len(key1) == 32  # MD5 tem 32 caracteres hex
+
+    def test_get_cache_key_diferente_para_arquivos_diferentes(self, tmp_path):
+        """Arquivos diferentes devem gerar chaves diferentes."""
+        from app.pipeline.separator import _get_cache_key
+
+        audio1 = tmp_path / "audio1.mp3"
+        audio2 = tmp_path / "audio2.mp3"
+        audio1.write_bytes(b"conteudo um")
+        audio2.write_bytes(b"conteudo dois")
+
+        assert _get_cache_key(audio1) != _get_cache_key(audio2)
+
+    def test_load_cache_retorna_none_quando_inexistente(self, audio_path, tmp_path):
+        """Deve retornar None quando cache não existe."""
+        from app.pipeline.separator import _load_from_cache
+
+        with patch("app.pipeline.separator.CACHE_DIR", tmp_path / "cache_vazio"):
+            resultado = _load_from_cache(audio_path)
+            assert resultado is None
+
+    def test_load_cache_retorna_none_quando_incompleto(self, audio_path, tmp_path):
+        """Deve retornar None quando cache está incompleto."""
+        from app.pipeline.separator import _load_from_cache, _get_cache_key
+
+        cache_key = _get_cache_key(audio_path)
+        cache_path = tmp_path / "cache" / cache_key
+        cache_path.mkdir(parents=True)
+
+        # Cria apenas alguns arquivos — falta harmonic.wav
+        for nome in ["vocals.wav", "bass.wav", "drums.wav", "other.wav"]:
+            (cache_path / nome).write_bytes(b"x" * 2048)
+
+        with patch("app.pipeline.separator.CACHE_DIR", tmp_path / "cache"):
+            resultado = _load_from_cache(audio_path)
+            assert resultado is None


### PR DESCRIPTION
## O que foi feito?
Implementação de cache baseado em hash MD5 para reutilizar faixas já separadas pelo Demucs.

## Tipo de Mudança
- [x] Nova funcionalidade (feat)

## Issue Relacionada
Closes #28

## Checklist
- [x] O código segue o padrão do projeto (ruff + black)
- [x] Os testes existentes continuam passando
- [x] Novos testes foram adicionados
- [x] A documentação foi atualizada

## Como Testar
1. Processar uma música pela primeira vez
2. Processar a mesma música novamente
3. Verificar nos logs: 'Cache encontrado'